### PR TITLE
Adjust method signatures to match parent

### DIFF
--- a/syntax.php
+++ b/syntax.php
@@ -27,7 +27,7 @@ class syntax_plugin_googlecal extends DokuWiki_Syntax_Plugin {
         $this->Lexer->addSpecialPattern('{{cal>[^}]*?}}', $mode, 'plugin_googlecal');
     }
 
-    function handle($match, $state, $pos, &$handler){        
+    function handle($match, $state, $pos, Doku_Handler $handler){        
         if(preg_match('/{{cal>(.*)/', $match)) {             // Hook for future features
             // Handle the simplified style of calendar tag
             $match = html_entity_decode(substr($match, 6, -2));
@@ -58,7 +58,7 @@ class syntax_plugin_googlecal extends DokuWiki_Syntax_Plugin {
         } // matched {{cal>...
     }
 
-    function render($mode, &$renderer, $data) {
+    function render($mode, Doku_Renderer $renderer, $data) {
         list($style, $url, $alt, $w, $h) = $data;
         
         if($mode == 'xhtml'){


### PR DESCRIPTION
Starting with PHP 7, classes that overide methods from their parent have to match their parent's method signature regarding type hints. Otherwise PHP will throw an error.

Your plugin seems not to match DokuWiki's method signatures causing it to fail under PHP7. This patch tries to fix that.

Please note that this patch and the resulting pull request were created using an automated tool. Something might have gone, wrong so please carefully check before merging.

If you think the code submitted is wrong, please feel free to close this PR and excuse the mess.
